### PR TITLE
Improve robustness of FlexLM and RLM Nagios checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# Nagios_Checks
-Custom check scripts for nagios.
+# Nagios Checks for FLEXlm and RLM
+
+This repository provides hardened Nagios plugins for monitoring FLEXlm and RLM
+license servers. Each plugin outputs Nagios-compatible status messages and
+exit codes to integrate cleanly with existing monitoring.
+
+## Available checks
+
+| Script | Purpose |
+| --- | --- |
+| `flexlm_diag_expiry.sh` | Reports upcoming licence expirations parsed from `lmutil lmstat` output. |
+| `flexlm_diag_status.sh` | Monitors FLEXlm server availability and raises UNKNOWN for ambiguous diagnostics. |
+| `rlm_diag_status.sh` | Monitors RLM server availability while validating command dependencies. |
+
+## Usage
+
+All scripts are POSIX shell and require the corresponding vendor utilities to be
+available on `PATH` (for example `lmutil` for FLEXlm or `rlmutil` for RLM). Run
+the desired script with `-h` to see its argument requirements and usage
+examples. Each script validates its inputs and returns one of the standard
+Nagios exit codes:
+
+* `0` (OK)
+* `1` (WARNING)
+* `2` (CRITICAL)
+* `3` (UNKNOWN)
+
+## Development
+
+These scripts are linted with `shellcheck`. Run the linter locally with:
+
+```sh
+shellcheck flexlm_diag_expiry.sh flexlm_diag_status.sh rlm_diag_status.sh
+```
+
+(If `shellcheck` is not installed the command will exit with a not found error.)

--- a/flexlm_diag_expiry.sh
+++ b/flexlm_diag_expiry.sh
@@ -1,49 +1,103 @@
 #!/usr/bin/env bash
+#
+# Nagios check for FLEXlm licence expiry
+# --------------------------------------
+#   * Validates arguments and dependency (lmutil)
+#   * Parses all expiry dates reported by lmdiag and chooses the furthest one
+#   * Returns standard Nagios codes (OK/CRITICAL/UNKNOWN)
+#
+# Usage: flexlm_diag_expiry.sh <port> <server> <feature> <alert_days>
+#
+# If <alert_days> days or more remain before the furthest expiry date, the check
+# returns OK. Otherwise it returns CRITICAL.
 
-lmutil=/usr/local/nagios/libexec/lmutil
-port=$1
-server=$2
-feature=$3
-alert_days=$4
+set -u
 
-# today's date in dd-Mon-YYYY, e.g. “07-Jul-2025”
-current_date=$(date +%d-%b-%Y)
-current_epoch=$(date -d "$current_date" +%s)
+LMUTIL_DEFAULT=/usr/local/nagios/libexec/lmutil
+lmutil=${LMUTIL_PATH:-$LMUTIL_DEFAULT}
 
-check_expiry() {
-    # run diagnostics and capture all 'expiry:' lines
-    diag_output=$("$lmutil" lmdiag -c "${port}@${server}" "${feature}" -n 2>/dev/null)
-    # extract each date after 'expiry:' (case‐insensitive), e.g. “30-jun-2026”
-    mapfile -t dates < <(echo "$diag_output" \
-        | grep -i 'expiry:' \
-        | sed -E 's/.*expiry:[[:space:]]*([0-9]{1,2}-[A-Za-z]{3}-[0-9]{4}).*/\1/i')
+usage() {
+    cat <<USAGE
+Usage: $(basename "$0") <port> <server> <feature> <alert_days>
 
-    if [ ${#dates[@]} -eq 0 ]; then
-        echo "UNKNOWN - no expiry dates found for feature '$feature'"
-        exit 3
+  port        FlexNet port number
+  server      Licence server hostname
+  feature     Feature to inspect
+  alert_days  Minimum number of days remaining before warning
+USAGE
+}
+
+nagios_exit() {
+    local code=$1
+    shift
+    echo "$*"
+    exit "$code"
+}
+
+validate_inputs() {
+    if [ $# -ne 4 ]; then
+        usage
+        nagios_exit 3 "UNKNOWN - invalid number of arguments"
     fi
 
-    # convert each to epoch and track max
-    max_epoch=0
-    for d in "${dates[@]}"; do
-        # normalize month to title case so 'date' will parse it
-        d_norm=$(echo "$d" | awk '{print tolower($0)}' | sed -E 's/^([0-9]+-[a-z]{3}-[0-9]{4})$/\1/' )
-        epoch=$(date -d "$d_norm" +%s 2>/dev/null)
-        (( epoch > max_epoch )) && max_epoch=$epoch
-    done
+    if [ ! -x "$lmutil" ]; then
+        nagios_exit 3 "UNKNOWN - lmutil not found or not executable at '$lmutil'"
+    fi
 
-    # compute days until that furthest expiry
-    diff_days=$(( (max_epoch - current_epoch) / 86400 ))
-
-    # choose OK vs CRITICAL
-    if [ "$diff_days" -ge 0 ] && [ "$diff_days" -ge "$alert_days" ]; then
-        echo "OK - $feature furthest expiry in $diff_days days"
-        exit 0
-    else
-        echo "CRITICAL - $feature furthest expiry in $diff_days days"
-        exit 2
+    if ! [[ $4 =~ ^[0-9]+$ ]]; then
+        nagios_exit 3 "UNKNOWN - alert_days must be an integer"
     fi
 }
 
-check_expiry
+check_expiry() {
+    local port=$1 server=$2 feature=$3 alert_days=$4
 
+    # Normalise locale so date parsing is deterministic
+    local current_date current_epoch
+    current_date=$(LC_ALL=C date +%d-%b-%Y)
+    current_epoch=$(LC_ALL=C date -d "$current_date" +%s)
+
+    local diag_output
+    if ! diag_output=$("$lmutil" lmdiag -c "${port}@${server}" "$feature" -n 2>&1); then
+        nagios_exit 3 "UNKNOWN - lmutil lmdiag failed: ${diag_output%%$'\n'*}"
+    fi
+
+    mapfile -t expiry_dates < <(echo "$diag_output" \
+        | grep -i "expiry:" \
+        | sed -E 's/.*expiry:[[:space:]]*([0-9]{1,2}-[A-Za-z]{3}-[0-9]{4}).*/\1/i')
+
+    if [ ${#expiry_dates[@]} -eq 0 ]; then
+        nagios_exit 3 "UNKNOWN - no expiry dates found for feature '$feature'"
+    fi
+
+    local max_epoch=0 valid_date=false
+    for raw_date in "${expiry_dates[@]}"; do
+        # Upper case the month so date(1) understands it reliably
+        local normalised
+        normalised=$(echo "$raw_date" | tr '[:lower:]' '[:upper:]')
+        local epoch
+        if epoch=$(LC_ALL=C date -d "$normalised" +%s 2>/dev/null); then
+            valid_date=true
+            if (( epoch > max_epoch )); then
+                max_epoch=$epoch
+            fi
+        fi
+    done
+
+    if [ "$valid_date" = false ]; then
+        nagios_exit 3 "UNKNOWN - failed to parse expiry dates for '$feature'"
+    fi
+
+    local diff_days=$(( (max_epoch - current_epoch) / 86400 ))
+
+    if (( diff_days >= alert_days )); then
+        nagios_exit 0 "OK - $feature furthest expiry in $diff_days days"
+    elif (( diff_days >= 0 )); then
+        nagios_exit 2 "CRITICAL - $feature furthest expiry in $diff_days days"
+    else
+        nagios_exit 2 "CRITICAL - $feature already expired ($diff_days days ago)"
+    fi
+}
+
+validate_inputs "$@"
+check_expiry "$@"

--- a/flexlm_diag_status.sh
+++ b/flexlm_diag_status.sh
@@ -1,16 +1,65 @@
 #!/usr/bin/env bash
-lmutil=/usr/local/nagios/libexec/lmutil
-port=$1
-server=$2
-feature=$3
-get_diag(){
-DIAG_STATUS=`$lmutil lmdiag -c ${port}@${server} ${feature} -n | grep -m 1 "This license can be checked out"`
-if [[ "$DIAG_STATUS" == "This license can be checked out" ]]; then
-    echo "OK - $feature can be checked out"
-     exit 0
-else
-    echo "Critical - $feature can't be checked out"
-     exit 2
-fi    
+#
+# Nagios check for FLEXlm feature availability
+# --------------------------------------------
+# Runs `lmutil lmdiag` for the requested feature and interprets the output. The
+# script validates its arguments and gracefully reports UNKNOWN when lmutil
+# cannot be executed.
+
+set -u
+
+LMUTIL_DEFAULT=/usr/local/nagios/libexec/lmutil
+lmutil=${LMUTIL_PATH:-$LMUTIL_DEFAULT}
+
+usage() {
+    cat <<USAGE
+Usage: $(basename "$0") <port> <server> <feature>
+
+  port     FlexNet port number
+  server   Licence server hostname
+  feature  Feature to inspect
+USAGE
 }
-get_diag
+
+nagios_exit() {
+    local code=$1
+    shift
+    echo "$*"
+    exit "$code"
+}
+
+validate_inputs() {
+    if [ $# -ne 3 ]; then
+        usage
+        nagios_exit 3 "UNKNOWN - invalid number of arguments"
+    fi
+
+    if [ ! -x "$lmutil" ]; then
+        nagios_exit 3 "UNKNOWN - lmutil not found or not executable at '$lmutil'"
+    fi
+}
+
+check_status() {
+    local port=$1 server=$2 feature=$3
+    local diag_output
+
+    if ! diag_output=$("$lmutil" lmdiag -c "${port}@${server}" "$feature" -n 2>&1); then
+        nagios_exit 3 "UNKNOWN - lmutil lmdiag failed: ${diag_output%%$'\n'*}"
+    fi
+
+    if echo "$diag_output" | grep -qi "This license can be checked out"; then
+        nagios_exit 0 "OK - $feature can be checked out"
+    fi
+
+    if echo "$diag_output" | grep -qi "This license cannot be checked out"; then
+        nagios_exit 2 "CRITICAL - $feature cannot be checked out"
+    fi
+
+    # We did not find the expected tokens; report UNKNOWN but include context
+    local first_line
+    first_line=$(echo "$diag_output" | head -n 1)
+    nagios_exit 3 "UNKNOWN - unexpected lmdiag output: ${first_line}"
+}
+
+validate_inputs "$@"
+check_status "$@"

--- a/rlm_diag_status.sh
+++ b/rlm_diag_status.sh
@@ -1,17 +1,63 @@
 #!/usr/bin/env bash
-rlm=/usr/local/nagios/libexec/rlmutil
-port=$1
-server=$2
-isv=$3
-get_diag(){
-DIAG_STATUS=`$rlm rlmstat -a -i ${isv} -c ${port}@${server} | grep -oh "server status on"`
-if [[ "$DIAG_STATUS" == "server status on" ]]; then
-    echo "OK - $isv can be checked out"
-     exit 0
-else
-    echo "Critical - $isv can't be checked out"
-     exit 2
-fi
-}
-get_diag
+#
+# Nagios check for RLM (Reprise License Manager) server health
+# ------------------------------------------------------------
+# Runs `rlmutil rlmstat` for the requested ISV, validating arguments and
+# handling failures gracefully.
 
+set -u
+
+RLMUTIL_DEFAULT=/usr/local/nagios/libexec/rlmutil
+rlm=${RLMUTIL_PATH:-$RLMUTIL_DEFAULT}
+
+usage() {
+    cat <<USAGE
+Usage: $(basename "$0") <port> <server> <isv>
+
+  port    RLM port number
+  server  Licence server hostname
+  isv     ISV (vendor) name
+USAGE
+}
+
+nagios_exit() {
+    local code=$1
+    shift
+    echo "$*"
+    exit "$code"
+}
+
+validate_inputs() {
+    if [ $# -ne 3 ]; then
+        usage
+        nagios_exit 3 "UNKNOWN - invalid number of arguments"
+    fi
+
+    if [ ! -x "$rlm" ]; then
+        nagios_exit 3 "UNKNOWN - rlmutil not found or not executable at '$rlm'"
+    fi
+}
+
+check_status() {
+    local port=$1 server=$2 isv=$3
+    local diag_output
+
+    if ! diag_output=$("$rlm" rlmstat -a -i "$isv" -c "${port}@${server}" 2>&1); then
+        nagios_exit 3 "UNKNOWN - rlmstat failed: ${diag_output%%$'\n'*}"
+    fi
+
+    if echo "$diag_output" | grep -qi "server status on"; then
+        nagios_exit 0 "OK - $isv can be checked out"
+    fi
+
+    if echo "$diag_output" | grep -qi "server status down"; then
+        nagios_exit 2 "CRITICAL - $isv server reported down"
+    fi
+
+    local first_line
+    first_line=$(echo "$diag_output" | head -n 1)
+    nagios_exit 3 "UNKNOWN - unexpected rlmstat output: ${first_line}"
+}
+
+validate_inputs "$@"
+check_status "$@"


### PR DESCRIPTION
## Summary
- add argument validation, usage helpers, and consistent Nagios exits to the FLEXlm expiry and status checks
- guard against missing lmutil/rlmutil binaries and propagate diagnostic failures as UNKNOWN
- provide clearer messaging when licence information is missing or unexpected

## Testing
- shellcheck flexlm_diag_expiry.sh flexlm_diag_status.sh rlm_diag_status.sh *(fails: shellcheck not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68ddc9062c688328ac7b215ea27a292d