### PR TITLE
Improve robustness of FLEXlm and RLM Nagios checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,67 @@
-# Nagios_Checks
-Custom check scripts for nagios.
+# FLEXlm / RLM Nagios Checks
+
+This repository provides a small collection of Bash scripts intended to be used
+as Nagios plugins for monitoring FLEXlm and RLM license servers. The scripts
+wrap the vendor utilities (`lmutil` and `rlmutil`) and surface their results in
+standard Nagios return codes.
+
+## Checks
+
+### `flexlm_diag_status.sh`
+Validates that a given FLEXlm feature can be checked out.
+
+```bash
+./flexlm_diag_status.sh [-l /path/to/lmutil] <port> <server> <feature>
+```
+
+* Returns `OK` when the feature can be checked out.
+* Returns `CRITICAL` when checkout is reported as impossible or the feature does
+  not exist.
+* Returns `UNKNOWN` if the diagnostic command fails or produces unexpected
+  output.
+
+### `flexlm_diag_expiry.sh`
+Reports the furthest license expiry for a FLEXlm feature and compares it to an
+alert window.
+
+```bash
+./flexlm_diag_expiry.sh [-l /path/to/lmutil] <port> <server> <feature> <alert_days>
+```
+
+* Returns `OK` when the furthest expiry is at least `<alert_days>` in the future.
+* Returns `CRITICAL` when the furthest expiry is sooner than `<alert_days>`.
+* Returns `UNKNOWN` when no expiry dates can be parsed or when the diagnostic
+  command fails.
+
+### `rlm_diag_status.sh`
+Checks that an RLM server is reporting an "on" status for the provided ISV
+module.
+
+```bash
+./rlm_diag_status.sh [-r /path/to/rlmutil] <port> <server> <isv>
+```
+
+* Returns `OK` when the server status string is detected.
+* Returns `CRITICAL` when an explicit failure string is present.
+* Returns `WARNING` when the server is up but reporting no licenses in use.
+* Returns `UNKNOWN` if the utility cannot be executed or the output is
+  unexpected.
+
+## Configuration
+
+Each script honours an environment variable that lets you override the default
+utility paths:
+
+* `LMUTIL_PATH` for the FLEXlm checks.
+* `RLMUTIL_PATH` for the RLM check.
+
+You can also override the path on the command line with `-l`/`-r`.
+
+## Exit Codes
+
+All scripts follow Nagios exit code semantics:
+
+* `0` – OK
+* `1` – WARNING
+* `2` – CRITICAL
+* `3` – UNKNOWN

--- a/flexlm_diag_expiry.sh
+++ b/flexlm_diag_expiry.sh
@@ -1,49 +1,112 @@
 #!/usr/bin/env bash
 
-lmutil=/usr/local/nagios/libexec/lmutil
+# Nagios plugin to check the furthest expiry date for a FLEXlm feature.
+# Returns CRITICAL when the furthest expiry is within the supplied alert window
+# or when the feature cannot be inspected.
+
+set -u
+
+LMUTIL=${LMUTIL_PATH:-/usr/local/nagios/libexec/lmutil}
+
+die_unknown() {
+    echo "UNKNOWN - $1" >&2
+    exit 3
+}
+
+print_usage() {
+    cat <<USAGE
+Usage: $0 [-l /path/to/lmutil] <port> <server> <feature> <alert_days>
+
+Options:
+  -l PATH    Override the lmutil binary to execute.
+  -h         Show this help message.
+
+Environment variables:
+  LMUTIL_PATH  Alternative way to point to lmutil.
+USAGE
+}
+
+lmutil_path=$LMUTIL
+
+while getopts ":l:h" opt; do
+    case "$opt" in
+        l)
+            lmutil_path=$OPTARG
+            ;;
+        h)
+            print_usage
+            exit 3
+            ;;
+        *)
+            die_unknown "invalid option"
+            ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+if [[ $# -ne 4 ]]; then
+    die_unknown "missing arguments"
+fi
+
 port=$1
 server=$2
 feature=$3
 alert_days=$4
 
-# today's date in dd-Mon-YYYY, e.g. “07-Jul-2025”
-current_date=$(date +%d-%b-%Y)
-current_epoch=$(date -d "$current_date" +%s)
+if ! [[ $alert_days =~ ^[0-9]+$ ]]; then
+    die_unknown "alert_days must be a non-negative integer"
+fi
 
-check_expiry() {
-    # run diagnostics and capture all 'expiry:' lines
-    diag_output=$("$lmutil" lmdiag -c "${port}@${server}" "${feature}" -n 2>/dev/null)
-    # extract each date after 'expiry:' (case‐insensitive), e.g. “30-jun-2026”
-    mapfile -t dates < <(echo "$diag_output" \
-        | grep -i 'expiry:' \
-        | sed -E 's/.*expiry:[[:space:]]*([0-9]{1,2}-[A-Za-z]{3}-[0-9]{4}).*/\1/i')
+alert_threshold=$((alert_days))
 
-    if [ ${#dates[@]} -eq 0 ]; then
-        echo "UNKNOWN - no expiry dates found for feature '$feature'"
-        exit 3
+if [[ ! -x "$lmutil_path" ]]; then
+    die_unknown "lmutil not found or not executable at '$lmutil_path'"
+fi
+
+current_epoch=$(date +%s)
+
+run_output=$("$lmutil_path" lmdiag -c "${port}@${server}" "$feature" -n 2>&1)
+run_status=$?
+if [[ $run_status -ne 0 ]]; then
+    die_unknown "lmutil failed: $(echo "$run_output" | tr '\n' ' ')"
+fi
+
+mapfile -t dates < <(echo "$run_output" \
+    | grep -i 'expiry:' \
+    | sed -E 's/.*expiry:[[:space:]]*([0-9]{1,2}-[A-Za-z]{3}-[0-9]{4}).*/\1/i')
+
+if [[ ${#dates[@]} -eq 0 ]]; then
+    die_unknown "no expiry dates found for feature '$feature'"
+fi
+
+max_epoch=0
+max_string=""
+for d in "${dates[@]}"; do
+    epoch=$(date -d "$d" +%s 2>/dev/null || echo '')
+    if [[ -z $epoch ]]; then
+        continue
     fi
-
-    # convert each to epoch and track max
-    max_epoch=0
-    for d in "${dates[@]}"; do
-        # normalize month to title case so 'date' will parse it
-        d_norm=$(echo "$d" | awk '{print tolower($0)}' | sed -E 's/^([0-9]+-[a-z]{3}-[0-9]{4})$/\1/' )
-        epoch=$(date -d "$d_norm" +%s 2>/dev/null)
-        (( epoch > max_epoch )) && max_epoch=$epoch
-    done
-
-    # compute days until that furthest expiry
-    diff_days=$(( (max_epoch - current_epoch) / 86400 ))
-
-    # choose OK vs CRITICAL
-    if [ "$diff_days" -ge 0 ] && [ "$diff_days" -ge "$alert_days" ]; then
-        echo "OK - $feature furthest expiry in $diff_days days"
-        exit 0
-    else
-        echo "CRITICAL - $feature furthest expiry in $diff_days days"
-        exit 2
+    if [[ $epoch -gt $max_epoch ]]; then
+        max_epoch=$epoch
+        max_string=$(date -d "@$epoch" '+%d-%b-%Y')
     fi
-}
+done
 
-check_expiry
+if [[ $max_epoch -le 0 ]]; then
+    die_unknown "unable to parse expiry dates"
+fi
 
+seconds_remaining=$(( max_epoch - current_epoch ))
+if [[ $seconds_remaining -ge 0 ]]; then
+    diff_days=$(( seconds_remaining / 86400 ))
+else
+    diff_days=$(( (seconds_remaining - 86399) / 86400 ))
+fi
+
+if [[ $diff_days -ge $alert_threshold ]]; then
+    echo "OK - $feature furthest expiry ($max_string) in $diff_days days"
+    exit 0
+fi
+
+echo "CRITICAL - $feature furthest expiry ($max_string) in $diff_days days"
+exit 2

--- a/flexlm_diag_status.sh
+++ b/flexlm_diag_status.sh
@@ -1,16 +1,87 @@
 #!/usr/bin/env bash
-lmutil=/usr/local/nagios/libexec/lmutil
+
+# Nagios plugin to verify whether a FLEXlm feature can be checked out.
+# The plugin expects a port, server, and feature name. Optionally the path to
+# lmutil may be overridden through the LMUTIL_PATH environment variable.
+
+set -u
+
+LMUTIL=${LMUTIL_PATH:-/usr/local/nagios/libexec/lmutil}
+
+print_usage() {
+    cat <<USAGE
+Usage: $0 [-l /path/to/lmutil] <port> <server> <feature>
+
+Options:
+  -l PATH    Override the lmutil binary to execute.
+  -h         Show this help message.
+
+Environment variables:
+  LMUTIL_PATH  Alternative way to point to lmutil.
+
+Returns standard Nagios codes based on whether the feature can be checked out.
+USAGE
+}
+
+lmutil_path=$LMUTIL
+
+while getopts ":l:h" opt; do
+    case "$opt" in
+        l)
+            lmutil_path=$OPTARG
+            ;;
+        h)
+            print_usage
+            exit 3
+            ;;
+        *)
+            echo "UNKNOWN - invalid option" >&2
+            print_usage >&2
+            exit 3
+            ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+if [[ $# -ne 3 ]]; then
+    echo "UNKNOWN - missing arguments" >&2
+    print_usage >&2
+    exit 3
+fi
+
 port=$1
 server=$2
 feature=$3
-get_diag(){
-DIAG_STATUS=`$lmutil lmdiag -c ${port}@${server} ${feature} -n | grep -m 1 "This license can be checked out"`
-if [[ "$DIAG_STATUS" == "This license can be checked out" ]]; then
+
+if [[ ! -x "$lmutil_path" ]]; then
+    echo "UNKNOWN - lmutil not found or not executable at '$lmutil_path'" >&2
+    exit 3
+fi
+
+run_output=$("$lmutil_path" lmdiag -c "${port}@${server}" "$feature" -n 2>&1)
+run_status=$?
+
+if [[ $run_status -ne 0 ]]; then
+    echo "UNKNOWN - lmutil failed: $run_output" | tr '\n' ' '
+    exit 3
+fi
+
+if echo "$run_output" | grep -q "This license can be checked out"; then
     echo "OK - $feature can be checked out"
-     exit 0
-else
-    echo "Critical - $feature can't be checked out"
-     exit 2
-fi    
-}
-get_diag
+    exit 0
+fi
+
+if echo "$run_output" | grep -qi "Checkout NOT possible"; then
+    echo "CRITICAL - $feature cannot be checked out"
+    exit 2
+fi
+
+if echo "$run_output" | grep -qi "No such feature"; then
+    echo "CRITICAL - feature '$feature' not found"
+    exit 2
+fi
+
+# If we get here, the output did not match known patterns. Surface it.
+first_line=$(echo "$run_output" | head -n 1)
+echo "UNKNOWN - unexpected lmdiag output: $first_line" | tr '\n' ' '
+exit 3

--- a/rlm_diag_status.sh
+++ b/rlm_diag_status.sh
@@ -1,17 +1,85 @@
 #!/usr/bin/env bash
-rlm=/usr/local/nagios/libexec/rlmutil
+
+# Nagios plugin to verify whether an RLM server is reporting available licenses
+# for a given ISV module. It wraps rlmutil rlmstat and parses the output for the
+# expected status lines.
+
+set -u
+
+RLMUTIL=${RLMUTIL_PATH:-/usr/local/nagios/libexec/rlmutil}
+
+print_usage() {
+    cat <<USAGE
+Usage: $0 [-r /path/to/rlmutil] <port> <server> <isv>
+
+Options:
+  -r PATH    Override the rlmutil binary to execute.
+  -h         Show this help message.
+
+Environment variables:
+  RLMUTIL_PATH  Alternative way to point to rlmutil.
+USAGE
+}
+
+rlmutil_path=$RLMUTIL
+
+while getopts ":r:h" opt; do
+    case "$opt" in
+        r)
+            rlmutil_path=$OPTARG
+            ;;
+        h)
+            print_usage
+            exit 3
+            ;;
+        *)
+            echo "UNKNOWN - invalid option" >&2
+            print_usage >&2
+            exit 3
+            ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+if [[ $# -ne 3 ]]; then
+    echo "UNKNOWN - missing arguments" >&2
+    print_usage >&2
+    exit 3
+fi
+
 port=$1
 server=$2
 isv=$3
-get_diag(){
-DIAG_STATUS=`$rlm rlmstat -a -i ${isv} -c ${port}@${server} | grep -oh "server status on"`
-if [[ "$DIAG_STATUS" == "server status on" ]]; then
-    echo "OK - $isv can be checked out"
-     exit 0
-else
-    echo "Critical - $isv can't be checked out"
-     exit 2
-fi
-}
-get_diag
 
+if [[ ! -x "$rlmutil_path" ]]; then
+    echo "UNKNOWN - rlmutil not found or not executable at '$rlmutil_path'" >&2
+    exit 3
+fi
+
+run_output=$("$rlmutil_path" rlmstat -a -i "$isv" -c "${port}@${server}" 2>&1)
+run_status=$?
+
+if [[ $run_status -ne 0 ]]; then
+    echo "UNKNOWN - rlmutil failed: $run_output" | tr '\n' ' '
+    exit 3
+fi
+
+if echo "$run_output" | grep -q "server status on"; then
+    echo "OK - $isv server status is up"
+    exit 0
+fi
+
+if echo "$run_output" | grep -qi "server not running"; then
+    echo "CRITICAL - $isv server reports not running"
+    exit 2
+fi
+
+if echo "$run_output" | grep -qi "no licenses in use"; then
+    # Server may be up but not granting licenses; treat as warning to highlight.
+    echo "WARNING - $isv server up but no licenses in use"
+    exit 1
+fi
+
+first_line=$(echo "$run_output" | head -n 1)
+echo "UNKNOWN - unexpected rlmstat output: $first_line" | tr '\n' ' '
+exit 3


### PR DESCRIPTION
## Summary
- harden FLEXlm feature status and expiry plugins with argument validation, error handling, and clearer messages
- add configuration documentation and usage details for all Nagios check scripts
- extend the RLM check to support overrides, warnings, and better diagnostics

## Testing
- bash -n flexlm_diag_status.sh
- bash -n flexlm_diag_expiry.sh
- bash -n rlm_diag_status.sh

------
https://chatgpt.com/codex/tasks/task_b_68ddcc88fd80832884ad8b6b75af4ce6